### PR TITLE
ISS1 Set explicit class loader for reading bundle

### DIFF
--- a/library/src/main/java/com/novoda/viewpageradapter/ViewPagerAdapterState.java
+++ b/library/src/main/java/com/novoda/viewpageradapter/ViewPagerAdapterState.java
@@ -25,7 +25,7 @@ public class ViewPagerAdapterState implements Parcelable {
     }
 
     private static ViewPagerAdapterState from(Parcel in) {
-        Bundle bundle = in.readBundle();
+        Bundle bundle = in.readBundle(ViewPagerAdapterState.class.getClassLoader());
         SparseArray<SparseArray<Parcelable>> viewStates = extractViewStatesFrom(bundle);
         return new ViewPagerAdapterState(viewStates);
     }


### PR DESCRIPTION
#### Problem/Goal

There was a lint warning when reading the bundle without specifying the class loader.

> Using the default class loader will not work if you are restoring your own classes. Consider using for example readBundle(getClass().getClassLoader()) instead.
> The documentation for Parcel#readParcelable(ClassLoader) (and its variations) says that you can pass in null to pick up the default class loader. However, that ClassLoader is a system class loader and is not able to find classes in your own application.  If you are writing your own classes into the Parcel (not just SDK classes like String and so on), then you should supply a ClassLoader for your application instead; a simple way to obtain one is to just call getClass().getClassLoader() from your own class.

We've seen something in the past in an internal project, getting crashes because it could not load `RecyclerView.State` - setting the class loader explicitly stopped those errors from occurring.
#### Solution

Set the class loader explicitly, using one of our classes to ensure we get a good ClassLoader.
##### Test(s) added

No. Although this issue manifested regularly, we never managed to reproduce it in a consistent way.

cc @Dorvaryn for a peek and to compare to the implementation in the internal project.
