### PR TITLE
VPA-7/ Overridable instantiated lifecycle 

### DIFF
--- a/library/src/main/java/com/novoda/viewpageradapter/ViewPagerAdapter.java
+++ b/library/src/main/java/com/novoda/viewpageradapter/ViewPagerAdapter.java
@@ -25,6 +25,7 @@ public abstract class ViewPagerAdapter<V extends View> extends PagerAdapter {
         instantiatedViews.put(view, position);
         restoreViewState(position, view);
         container.addView(view);
+        onViewInstantiated(view, position);
 
         // key with which to associate this view
         return view;
@@ -55,6 +56,15 @@ public abstract class ViewPagerAdapter<V extends View> extends PagerAdapter {
             return;
         }
         view.restoreHierarchyState(parcelableSparseArray);
+    }
+
+    /**
+     * Optional method to know when the View has been created, bound and restored.
+     *
+     * @param view     the created and bound view
+     * @param position the position of the data set that is to be represented by this view
+     */
+    protected void onViewInstantiated(V view, int position) {
     }
 
     @Override


### PR DESCRIPTION
#### Problem/Goal

Fixes #7  

Adding extra overridable method to expose when the item View has been created, bound and restored. 

This can/will be used when an item view needs to decide whether to fetch new data or not depending on if it has restored its state. 

##### Test(s) added 

no tests, it's not _reallyyy_ possible to test an empty method.

##### Screenshots

no UI changes