### PR TITLE
Call bind with state on notifyDataSetChanged

### DIFF
--- a/library/src/main/java/com/novoda/viewpageradapter/ViewPagerAdapter.java
+++ b/library/src/main/java/com/novoda/viewpageradapter/ViewPagerAdapter.java
@@ -69,7 +69,9 @@ public abstract class ViewPagerAdapter<V extends View> extends PagerAdapter {
     public void notifyDataSetChanged() {
         super.notifyDataSetChanged();
         for (Map.Entry<V, Integer> entry : instantiatedViews.entrySet()) {
-            bindView(entry.getKey(), entry.getValue());
+            int position = entry.getValue();
+            SparseArray<Parcelable> viewState = this.viewPagerAdapterState.get(position);
+            bindView(entry.getKey(), position, viewState);
         }
     }
 

--- a/library/src/main/java/com/novoda/viewpageradapter/ViewPagerAdapter.java
+++ b/library/src/main/java/com/novoda/viewpageradapter/ViewPagerAdapter.java
@@ -70,7 +70,7 @@ public abstract class ViewPagerAdapter<V extends View> extends PagerAdapter {
         super.notifyDataSetChanged();
         for (Map.Entry<V, Integer> entry : instantiatedViews.entrySet()) {
             int position = entry.getValue();
-            SparseArray<Parcelable> viewState = this.viewPagerAdapterState.get(position);
+            SparseArray<Parcelable> viewState = viewPagerAdapterState.get(position);
             bindView(entry.getKey(), position, viewState);
         }
     }


### PR DESCRIPTION
#### Problem/Goal

Calling `notifyDataSetChanged()` will rebind the views losing the state

#### Solution

Instead of calling `bindView(V view, int position)`, let's call `bindView(V view, int position, @Nullable SparseArray<Parcelable> viewState)` with the state found in `viewPagerAdapterState`.

##### Test(s) added 

Android class, no test

##### Screenshots

Nope.