### PR TITLE
View Id restoration

### DIFF
--- a/library/src/main/java/com/novoda/viewpageradapter/ViewPagerAdapter.java
+++ b/library/src/main/java/com/novoda/viewpageradapter/ViewPagerAdapter.java
@@ -20,7 +20,7 @@ public abstract class ViewPagerAdapter<V extends View> extends PagerAdapter {
     @Override
     public V instantiateItem(ViewGroup container, int position) {
         V view = createView(container, position);
-        SparseArray<Parcelable> viewState = viewPagerAdapterState.get(position);
+        SparseArray<Parcelable> viewState = viewPagerAdapterState.getViewState(position);
 
         int restoredId = viewPagerAdapterState.getId(position);
         view.setId(restoredId == View.NO_ID ? viewIdGenerator.generateViewId() : restoredId);
@@ -72,7 +72,7 @@ public abstract class ViewPagerAdapter<V extends View> extends PagerAdapter {
         super.notifyDataSetChanged();
         for (Map.Entry<V, Integer> entry : instantiatedViews.entrySet()) {
             int position = entry.getValue();
-            SparseArray<Parcelable> viewState = viewPagerAdapterState.get(position);
+            SparseArray<Parcelable> viewState = viewPagerAdapterState.getViewState(position);
             bindView(entry.getKey(), position, viewState);
         }
     }

--- a/library/src/main/java/com/novoda/viewpageradapter/ViewPagerAdapter.java
+++ b/library/src/main/java/com/novoda/viewpageradapter/ViewPagerAdapter.java
@@ -21,11 +21,11 @@ public abstract class ViewPagerAdapter<V extends View> extends PagerAdapter {
     public V instantiateItem(ViewGroup container, int position) {
         V view = createView(container, position);
         SparseArray<Parcelable> viewState = viewPagerAdapterState.get(position);
-        bindView(view, position, viewState);
 
         int restoredId = viewPagerAdapterState.getId(position);
         view.setId(restoredId == View.NO_ID ? viewIdGenerator.generateViewId() : restoredId);
 
+        bindView(view, position, viewState);
         instantiatedViews.put(view, position);
         container.addView(view);
 

--- a/library/src/main/java/com/novoda/viewpageradapter/ViewPagerAdapter.java
+++ b/library/src/main/java/com/novoda/viewpageradapter/ViewPagerAdapter.java
@@ -23,7 +23,9 @@ public abstract class ViewPagerAdapter<V extends View> extends PagerAdapter {
         SparseArray<Parcelable> viewState = viewPagerAdapterState.get(position);
         bindView(view, position, viewState);
 
-        view.setId(viewIdGenerator.generateViewId());
+        int restoredId = viewPagerAdapterState.getId(position);
+        view.setId(restoredId == View.NO_ID ? viewIdGenerator.generateViewId() : restoredId);
+
         instantiatedViews.put(view, position);
         container.addView(view);
 
@@ -75,7 +77,8 @@ public abstract class ViewPagerAdapter<V extends View> extends PagerAdapter {
         }
     }
 
-    @SuppressWarnings("unchecked") // `key` is the object we return in `instantiateItem(ViewGroup container, int position)`
+    @SuppressWarnings("unchecked")
+    // `key` is the object we return in `instantiateItem(ViewGroup container, int position)`
     @Override
     public void destroyItem(ViewGroup container, int position, Object key) {
         V view = (V) key;
@@ -86,7 +89,7 @@ public abstract class ViewPagerAdapter<V extends View> extends PagerAdapter {
     private void saveViewState(int position, V view) {
         SparseArray<Parcelable> viewState = new SparseArray<>();
         view.saveHierarchyState(viewState);
-        viewPagerAdapterState.put(position, viewState);
+        viewPagerAdapterState.put(view.getId(), position, viewState);
     }
 
     @Override

--- a/library/src/main/java/com/novoda/viewpageradapter/ViewPagerAdapterState.java
+++ b/library/src/main/java/com/novoda/viewpageradapter/ViewPagerAdapterState.java
@@ -66,7 +66,7 @@ public class ViewPagerAdapterState implements Parcelable {
         viewStates.put(position, viewState);
     }
 
-    public SparseArray<Parcelable> get(int position) {
+    public SparseArray<Parcelable> getViewState(int position) {
         return viewStates.get(position);
     }
 

--- a/library/src/main/java/com/novoda/viewpageradapter/ViewPagerAdapterState.java
+++ b/library/src/main/java/com/novoda/viewpageradapter/ViewPagerAdapterState.java
@@ -4,6 +4,8 @@ import android.os.Bundle;
 import android.os.Parcel;
 import android.os.Parcelable;
 import android.util.SparseArray;
+import android.util.SparseIntArray;
+import android.view.View;
 
 public class ViewPagerAdapterState implements Parcelable {
 
@@ -18,16 +20,31 @@ public class ViewPagerAdapterState implements Parcelable {
         }
     };
 
+    private static final String KEY_VIEW_IDS = "id";
+
+    private final SparseIntArray viewIds;
     private final SparseArray<SparseArray<Parcelable>> viewStates;
 
     public static ViewPagerAdapterState newInstance() {
-        return new ViewPagerAdapterState(new SparseArray<SparseArray<Parcelable>>());
+        SparseIntArray viewIds = new SparseIntArray();
+        SparseArray<SparseArray<Parcelable>> viewStates = new SparseArray<>();
+        return new ViewPagerAdapterState(viewIds, viewStates);
     }
 
     private static ViewPagerAdapterState from(Parcel in) {
         Bundle bundle = in.readBundle(ViewPagerAdapterState.class.getClassLoader());
         SparseArray<SparseArray<Parcelable>> viewStates = extractViewStatesFrom(bundle);
-        return new ViewPagerAdapterState(viewStates);
+        SparseIntArray viewIds = extractIdsFrom(bundle);
+        return new ViewPagerAdapterState(viewIds, viewStates);
+    }
+
+    private static SparseIntArray extractIdsFrom(Bundle bundle) {
+        SparseIntArray output = new SparseIntArray();
+        int[] ids = bundle.getIntArray(KEY_VIEW_IDS);
+        for (int index = 0; index < ids.length; index++) {
+            output.put(index, ids[index]);
+        }
+        return output;
     }
 
     private static SparseArray<SparseArray<Parcelable>> extractViewStatesFrom(Bundle bundle) {
@@ -39,11 +56,13 @@ public class ViewPagerAdapterState implements Parcelable {
         return viewStates;
     }
 
-    private ViewPagerAdapterState(SparseArray<SparseArray<Parcelable>> viewStates) {
+    private ViewPagerAdapterState(SparseIntArray viewIds, SparseArray<SparseArray<Parcelable>> viewStates) {
+        this.viewIds = viewIds;
         this.viewStates = viewStates;
     }
 
-    public void put(int position, SparseArray<Parcelable> viewState) {
+    public void put(int viewId, int position, SparseArray<Parcelable> viewState) {
+        viewIds.put(position, viewId);
         viewStates.put(position, viewState);
     }
 
@@ -51,14 +70,28 @@ public class ViewPagerAdapterState implements Parcelable {
         return viewStates.get(position);
     }
 
+    public int getId(int position) {
+        return viewIds.get(position, View.NO_ID);
+    }
+
     @Override
     public void writeToParcel(Parcel dest, int flags) {
         Bundle bundle = new Bundle();
+        int[] viewIds = viewIdsArray();
+        bundle.putIntArray(KEY_VIEW_IDS, viewIds);
         for (int i = 0; i < viewStates.size(); i++) {
             SparseArray<Parcelable> viewState = viewStates.get(i);
             bundle.putSparseParcelableArray(String.valueOf(i), viewState);
         }
         dest.writeBundle(bundle);
+    }
+
+    private int[] viewIdsArray() {
+        int[] output = new int[viewIds.size()];
+        for (int index = 0; index < viewIds.size(); index++) {
+            output[index] = viewIds.get(index);
+        }
+        return output;
     }
 
     @Override


### PR DESCRIPTION
#### Problem/Goal

Fixes #12  (and the demo not restoring the scroll position)

The root view state was being lost due to a new id being set on the view each time `instantiateItem` was called. 

#### Solution

Keep track and restore the views id before attempting to restore the state back on the view.

##### Test(s) added 

nil, next PR will add some 😉 

##### Screenshots

| Before | After |
| ------ | ----- |
|![before](https://cloud.githubusercontent.com/assets/1848238/25151337/20f8819e-247d-11e7-9bb4-cdb974c91f51.gif)|![after](https://cloud.githubusercontent.com/assets/1848238/25151379/43012926-247d-11e7-9e5f-f12d9ec9f0d6.gif)|