### PR TITLE
Fix crash when restoring state

### DIFF
--- a/library/src/main/java/com/novoda/viewpageradapter/ViewPagerAdapterState.java
+++ b/library/src/main/java/com/novoda/viewpageradapter/ViewPagerAdapterState.java
@@ -21,6 +21,7 @@ public class ViewPagerAdapterState implements Parcelable {
     };
 
     private static final String KEY_VIEW_IDS = "id";
+    private static final String KEY_VIEW_STATE = "state";
 
     private final SparseIntArray viewIds;
     private final SparseArray<SparseArray<Parcelable>> viewStates;
@@ -48,9 +49,10 @@ public class ViewPagerAdapterState implements Parcelable {
     }
 
     private static SparseArray<SparseArray<Parcelable>> extractViewStatesFrom(Bundle bundle) {
-        SparseArray<SparseArray<Parcelable>> viewStates = new SparseArray<>(bundle.keySet().size());
-        for (String key : bundle.keySet()) {
-            SparseArray<Parcelable> sparseParcelableArray = bundle.getSparseParcelableArray(key);
+        Bundle viewStateBundle = bundle.getBundle(KEY_VIEW_STATE);
+        SparseArray<SparseArray<Parcelable>> viewStates = new SparseArray<>(viewStateBundle.keySet().size());
+        for (String key : viewStateBundle.keySet()) {
+            SparseArray<Parcelable> sparseParcelableArray = viewStateBundle.getSparseParcelableArray(key);
             viewStates.put(Integer.parseInt(key), sparseParcelableArray);
         }
         return viewStates;
@@ -79,10 +81,8 @@ public class ViewPagerAdapterState implements Parcelable {
         Bundle bundle = new Bundle();
         int[] viewIds = viewIdsArray();
         bundle.putIntArray(KEY_VIEW_IDS, viewIds);
-        for (int i = 0; i < viewStates.size(); i++) {
-            SparseArray<Parcelable> viewState = viewStates.get(i);
-            bundle.putSparseParcelableArray(String.valueOf(i), viewState);
-        }
+        Bundle viewStateBundle = viewStateBundle();
+        bundle.putBundle(KEY_VIEW_STATE, viewStateBundle);
         dest.writeBundle(bundle);
     }
 
@@ -92,6 +92,15 @@ public class ViewPagerAdapterState implements Parcelable {
             output[index] = viewIds.get(index);
         }
         return output;
+    }
+
+    private Bundle viewStateBundle() {
+        Bundle viewStateBundle = new Bundle();
+        for (int i = 0; i < viewStates.size(); i++) {
+            SparseArray<Parcelable> viewState = viewStates.get(i);
+            viewStateBundle.putSparseParcelableArray(String.valueOf(i), viewState);
+        }
+        return viewStateBundle;
     }
 
     @Override


### PR DESCRIPTION
#### Problem/Goal

There is a crash when the activity restores the state due to the fact that a String with the value `"id"` is tried to be parsed into an Integer.

<details>
  <summary>Stacktrace</summary>
Caused by: java.lang.NumberFormatException: Invalid int: "id"
  at java.lang.Integer.invalidInt(Integer.java:138)
  at java.lang.Integer.parse(Integer.java:410)
  at java.lang.Integer.parseInt(Integer.java:367)
  at java.lang.Integer.parseInt(Integer.java:334)
  at com.novoda.viewpageradapter.ViewPagerAdapterState.extractViewStatesFrom(ViewPagerAdapterState.java:54)
  at com.novoda.viewpageradapter.ViewPagerAdapterState.from(ViewPagerAdapterState.java:36)
  at com.novoda.viewpageradapter.ViewPagerAdapterState.access$000(ViewPagerAdapterState.java:10)
  at com.novoda.viewpageradapter.ViewPagerAdapterState$1.createFromParcel(ViewPagerAdapterState.java:15)
  at com.novoda.viewpageradapter.ViewPagerAdapterState$1.createFromParcel(ViewPagerAdapterState.java:12)
  at android.os.Parcel.readParcelable(Parcel.java:2367)
  at android.support.v4.view.ViewPager$SavedState.<init>(ViewPager.java:1454)
  at android.support.v4.view.ViewPager$SavedState$1.createFromParcel(ViewPager.java:1440)
  at android.support.v4.view.ViewPager$SavedState$1.createFromParcel(ViewPager.java:1437)
  at android.support.v4.os.ParcelableCompatCreatorHoneycombMR2.createFromParcel(ParcelableCompatHoneycombMR2.java:46)
  at android.os.Parcel.readParcelable(Parcel.java:2365)
  at android.os.Parcel.readValue(Parcel.java:2264)
  at android.os.Parcel.readSparseArrayInternal(Parcel.java:2675)
  at android.os.Parcel.readSparseArray(Parcel.java:1967)
  at android.os.Parcel.readValue(Parcel.java:2321)
  at android.os.Parcel.readArrayMapInternal(Parcel.java:2614)
  at android.os.BaseBundle.unparcel(BaseBundle.java:221)
  at android.os.Bundle.getSparseParcelableArray(Bundle.java:856)
  at com.android.internal.policy.PhoneWindow.restoreHierarchyState(PhoneWindow.java:2033)
  at android.app.Activity.onRestoreInstanceState(Activity.java:1008)
  at android.app.Activity.performRestoreInstanceState(Activity.java:963)
</details>

#### Solution

The proper thing to solve this, as pointed out by @ouchadam, is to put the view state in a different `Bundle`, and put that `Bundle` into the `Bundle` that is written into the `Parcel`. This way, integer keys are not mixed up with String keys.

##### Test(s) added 

Nope

##### Screenshots

No UI changes, crashing before, not anymore 😂 