### PR TITLE
6/Replace WeakHashMap with HashMap and explicitly remove Views

### DIFF
--- a/library/src/main/java/com/novoda/viewpageradapter/ViewPagerAdapter.java
+++ b/library/src/main/java/com/novoda/viewpageradapter/ViewPagerAdapter.java
@@ -7,12 +7,12 @@ import android.util.SparseArray;
 import android.view.View;
 import android.view.ViewGroup;
 
+import java.util.HashMap;
 import java.util.Map;
-import java.util.WeakHashMap;
 
 public abstract class ViewPagerAdapter<V extends View> extends PagerAdapter {
 
-    private final Map<V, Integer> instantiatedViews = new WeakHashMap<>();
+    private final Map<V, Integer> instantiatedViews = new HashMap<>();
     private final ViewIdGenerator viewIdGenerator = new ViewIdGenerator();
 
     private ViewPagerAdapterState viewPagerAdapterState = ViewPagerAdapterState.newInstance();
@@ -84,6 +84,7 @@ public abstract class ViewPagerAdapter<V extends View> extends PagerAdapter {
         V view = (V) key;
         saveViewState(position, view);
         container.removeView(view);
+        instantiatedViews.remove(view);
     }
 
     private void saveViewState(int position, V view) {


### PR DESCRIPTION
Fixes #6 

#### Problem/Goal

We're binding to views that aren't even part of the viewpager anymore.

#### Solution

Swap from WeakHashMap to HashMap and now we explicitly remove Views from this map when we remove them from the ViewPager.

The WeakHashMap _could_ have worked, but because we cannot guarantee when GC occurs, we're often keeping a load of Views inside it, even though we don't care about them anymore.

Thanks @rock3r for the chat!