### PR TITLE
Don't use restoredId if there's no id to restore

### DIFF
--- a/library/src/main/java/com/novoda/viewpageradapter/ViewPagerAdapter.java
+++ b/library/src/main/java/com/novoda/viewpageradapter/ViewPagerAdapter.java
@@ -20,18 +20,22 @@ public abstract class ViewPagerAdapter<V extends View> extends PagerAdapter {
     @Override
     public V instantiateItem(ViewGroup container, int position) {
         V view = createView(container, position);
+
+        ensureViewHasValidId(view, position);
+
         SparseArray<Parcelable> viewState = viewPagerAdapterState.getViewState(position);
-
-        if (view.getId() == View.NO_ID) {
-            int restoredId = viewPagerAdapterState.getId(position);
-            view.setId(restoredId == View.NO_ID ? viewIdGenerator.generateViewId() : restoredId);
-        }
-
         bindView(view, position, viewState);
         instantiatedViews.put(view, position);
         container.addView(view);
 
         return view;
+    }
+
+    private void ensureViewHasValidId(V view, int position) {
+        if (view.getId() == View.NO_ID) {
+            int restoredId = viewPagerAdapterState.getId(position);
+            view.setId(restoredId == View.NO_ID ? viewIdGenerator.generateViewId() : restoredId);
+        }
     }
 
     /**
@@ -65,7 +69,8 @@ public abstract class ViewPagerAdapter<V extends View> extends PagerAdapter {
      * @param view     the view to bind
      * @param position the position of the data set that is to be represented by this view
      */
-    protected abstract void bindView(V view, int position);
+    protected void bindView(V view, int position) {
+    }
 
     @Override
     public void notifyDataSetChanged() {

--- a/library/src/main/java/com/novoda/viewpageradapter/ViewPagerAdapter.java
+++ b/library/src/main/java/com/novoda/viewpageradapter/ViewPagerAdapter.java
@@ -31,7 +31,6 @@ public abstract class ViewPagerAdapter<V extends View> extends PagerAdapter {
         instantiatedViews.put(view, position);
         container.addView(view);
 
-        // key with which to associate this view
         return view;
     }
 
@@ -53,7 +52,7 @@ public abstract class ViewPagerAdapter<V extends View> extends PagerAdapter {
      * @param position  the position of the data set that is to be represented by this view
      * @param viewState the state of the view
      */
-    protected void bindView(V view, int position, @Nullable SparseArray<Parcelable> viewState) {
+    private void bindView(V view, int position, @Nullable SparseArray<Parcelable> viewState) {
         bindView(view, position);
         if (viewState != null) {
             view.restoreHierarchyState(viewState);
@@ -66,8 +65,7 @@ public abstract class ViewPagerAdapter<V extends View> extends PagerAdapter {
      * @param view     the view to bind
      * @param position the position of the data set that is to be represented by this view
      */
-    protected void bindView(V view, int position) {
-    }
+    protected abstract void bindView(V view, int position);
 
     @Override
     public void notifyDataSetChanged() {

--- a/library/src/main/java/com/novoda/viewpageradapter/ViewPagerAdapter.java
+++ b/library/src/main/java/com/novoda/viewpageradapter/ViewPagerAdapter.java
@@ -22,8 +22,10 @@ public abstract class ViewPagerAdapter<V extends View> extends PagerAdapter {
         V view = createView(container, position);
         SparseArray<Parcelable> viewState = viewPagerAdapterState.getViewState(position);
 
-        int restoredId = viewPagerAdapterState.getId(position);
-        view.setId(restoredId == View.NO_ID ? viewIdGenerator.generateViewId() : restoredId);
+        if (view.getId() == View.NO_ID) {
+            int restoredId = viewPagerAdapterState.getId(position);
+            view.setId(restoredId == View.NO_ID ? viewIdGenerator.generateViewId() : restoredId);
+        }
 
         bindView(view, position, viewState);
         instantiatedViews.put(view, position);

--- a/library/src/main/java/com/novoda/viewpageradapter/ViewPagerAdapterState.java
+++ b/library/src/main/java/com/novoda/viewpageradapter/ViewPagerAdapterState.java
@@ -7,7 +7,7 @@ import android.util.SparseArray;
 import android.util.SparseIntArray;
 import android.view.View;
 
-public class ViewPagerAdapterState implements Parcelable {
+class ViewPagerAdapterState implements Parcelable {
 
     public static final Creator<ViewPagerAdapterState> CREATOR = new Creator<ViewPagerAdapterState>() {
 
@@ -26,7 +26,7 @@ public class ViewPagerAdapterState implements Parcelable {
     private final SparseIntArray viewIds;
     private final SparseArray<SparseArray<Parcelable>> viewStates;
 
-    public static ViewPagerAdapterState newInstance() {
+    static ViewPagerAdapterState newInstance() {
         SparseIntArray viewIds = new SparseIntArray();
         SparseArray<SparseArray<Parcelable>> viewStates = new SparseArray<>();
         return new ViewPagerAdapterState(viewIds, viewStates);
@@ -40,8 +40,11 @@ public class ViewPagerAdapterState implements Parcelable {
     }
 
     private static SparseIntArray extractIdsFrom(Bundle bundle) {
-        SparseIntArray output = new SparseIntArray();
         int[] ids = bundle.getIntArray(KEY_VIEW_IDS);
+        if (ids == null) {
+            return new SparseIntArray();
+        }
+        SparseIntArray output = new SparseIntArray();
         for (int index = 0; index < ids.length; index++) {
             output.put(index, ids[index]);
         }
@@ -50,6 +53,9 @@ public class ViewPagerAdapterState implements Parcelable {
 
     private static SparseArray<SparseArray<Parcelable>> extractViewStatesFrom(Bundle bundle) {
         Bundle viewStateBundle = bundle.getBundle(KEY_VIEW_STATE);
+        if (viewStateBundle == null) {
+            return new SparseArray<>();
+        }
         SparseArray<SparseArray<Parcelable>> viewStates = new SparseArray<>(viewStateBundle.keySet().size());
         for (String key : viewStateBundle.keySet()) {
             SparseArray<Parcelable> sparseParcelableArray = viewStateBundle.getSparseParcelableArray(key);
@@ -63,16 +69,16 @@ public class ViewPagerAdapterState implements Parcelable {
         this.viewStates = viewStates;
     }
 
-    public void put(int viewId, int position, SparseArray<Parcelable> viewState) {
+    void put(int viewId, int position, SparseArray<Parcelable> viewState) {
         viewIds.put(position, viewId);
         viewStates.put(position, viewState);
     }
 
-    public SparseArray<Parcelable> getViewState(int position) {
+    SparseArray<Parcelable> getViewState(int position) {
         return viewStates.get(position);
     }
 
-    public int getId(int position) {
+    int getId(int position) {
         return viewIds.get(position, View.NO_ID);
     }
 


### PR DESCRIPTION
#### Problem/Goal
When integrating v0.9.6 into a client project, we found a crash on launching a specific activity.

This was happening because a view's id was being changed by the ViewPagerAdapter class, meaning when we called `findViewById` to try and obtain it, we got `null`.

The id was changed because there was no previous instances of a view at that position in the `ViewPagerAdapterState` instance, so it was being re-assigned.

#### Solution
The solution was just to make sure that only views with no id have an id assigned to them.

##### Test(s) added 
No tests added as there are no tests in this entire project.

##### Screenshots
No screenshots I'm afraid, but the demo app still works the same, and our client project doesn't crash now.