### PR TITLE
Extract explicit restore/save state methods

### DIFF
--- a/library/src/main/java/com/novoda/viewpageradapter/ViewPagerAdapter.java
+++ b/library/src/main/java/com/novoda/viewpageradapter/ViewPagerAdapter.java
@@ -58,24 +58,35 @@ public abstract class ViewPagerAdapter<V extends View> extends PagerAdapter {
     /**
      * Bind the view to the item at the given position with view state.
      *
-     * @param view      the view to bind
+     * @param view      the page view to bind
      * @param position  the position of the data set that is to be represented by this view
      * @param viewState the state of the view
      */
-    protected void bindView(V view, int position, @Nullable SparseArray<Parcelable> viewState) {
+    private void bindView(V view, int position, @Nullable SparseArray<Parcelable> viewState) {
         bindView(view, position);
-        if (viewState != null) {
-            view.restoreHierarchyState(viewState);
-        }
+        restoreHierarchyState(view, position, viewState);
     }
 
     /**
      * Bind the view to the item at the given position.
      *
-     * @param view     the view to bind
+     * @param view     the page view to bind
      * @param position the position of the data set that is to be represented by this view
      */
     protected void bindView(V view, int position) {
+    }
+
+    /**
+     * Restore state on the given page view.
+     *
+     * @param view      the page view to restore state on
+     * @param position  the position of the data set that is to be represented by this view
+     * @param viewState the state of the view
+     */
+    protected void restoreHierarchyState(V view, int position, @Nullable SparseArray<Parcelable> viewState) {
+        if (viewState != null) {
+            view.restoreHierarchyState(viewState);
+        }
     }
 
     @Override
@@ -100,8 +111,19 @@ public abstract class ViewPagerAdapter<V extends View> extends PagerAdapter {
 
     private void saveViewState(int position, V view) {
         SparseArray<Parcelable> viewState = new SparseArray<>();
-        view.saveHierarchyState(viewState);
+        saveHierarchyState(view, position, viewState);
         viewPagerAdapterState.put(view.getId(), position, viewState);
+    }
+
+    /**
+     * Save state on the given page view.
+     *
+     * @param view      the page view to restore state on
+     * @param position  the position of the data set that is to be represented by this view
+     * @param viewState the state of the view
+     */
+    protected void saveHierarchyState(V view, int position, SparseArray<Parcelable> viewState) {
+        view.saveHierarchyState(viewState);
     }
 
     @Override

--- a/library/src/main/java/com/novoda/viewpageradapter/ViewPagerAdapter.java
+++ b/library/src/main/java/com/novoda/viewpageradapter/ViewPagerAdapter.java
@@ -8,9 +8,12 @@ import android.view.View;
 import android.view.ViewGroup;
 
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 
 public abstract class ViewPagerAdapter<V extends View> extends PagerAdapter {
+
+    private static final String ILLEGAL_STATE_ID_ON_VIEW = "Found existing ID on view: %s. " + ViewPagerAdapter.class.getSimpleName() + " is responsible for setting/restoring page view IDs.";
 
     private final Map<V, Integer> instantiatedViews = new HashMap<>();
     private final ViewIdGenerator viewIdGenerator = new ViewIdGenerator();
@@ -22,6 +25,7 @@ public abstract class ViewPagerAdapter<V extends View> extends PagerAdapter {
         V view = createView(container, position);
         SparseArray<Parcelable> viewState = viewPagerAdapterState.getViewState(position);
 
+        assertViewHasNoId(view);
         int restoredId = viewPagerAdapterState.getId(position);
         view.setId(restoredId == View.NO_ID ? viewIdGenerator.generateViewId() : restoredId);
 
@@ -31,6 +35,13 @@ public abstract class ViewPagerAdapter<V extends View> extends PagerAdapter {
 
         // key with which to associate this view
         return view;
+    }
+
+    private void assertViewHasNoId(V view) {
+        if (view.getId() != View.NO_ID) {
+            String errorMessage = String.format(Locale.US, ILLEGAL_STATE_ID_ON_VIEW, view);
+            throw new IllegalStateException(errorMessage);
+        }
     }
 
     /**

--- a/library/src/main/java/com/novoda/viewpageradapter/ViewPagerAdapter.java
+++ b/library/src/main/java/com/novoda/viewpageradapter/ViewPagerAdapter.java
@@ -13,7 +13,7 @@ import java.util.Map;
 
 public abstract class ViewPagerAdapter<V extends View> extends PagerAdapter {
 
-    private static final String ILLEGAL_STATE_ID_ON_VIEW = "Found existing ID on view: %s. " + ViewPagerAdapter.class.getSimpleName() + " is responsible for setting/restoring page view IDs.";
+    private static final String ILLEGAL_STATE_ID_ON_VIEW = "The view created for position %d has an ID. Page view IDs must be set by the adapter to deal with state saving and restoring. Make sure your inflated views have an ID of View.NO_ID";
 
     private final Map<V, Integer> instantiatedViews = new HashMap<>();
     private final ViewIdGenerator viewIdGenerator = new ViewIdGenerator();
@@ -25,7 +25,7 @@ public abstract class ViewPagerAdapter<V extends View> extends PagerAdapter {
         V view = createView(container, position);
         SparseArray<Parcelable> viewState = viewPagerAdapterState.getViewState(position);
 
-        assertViewHasNoId(view);
+        assertViewHasNoId(position, view);
         int restoredId = viewPagerAdapterState.getId(position);
         view.setId(restoredId == View.NO_ID ? viewIdGenerator.generateViewId() : restoredId);
 
@@ -37,9 +37,9 @@ public abstract class ViewPagerAdapter<V extends View> extends PagerAdapter {
         return view;
     }
 
-    private void assertViewHasNoId(V view) {
+    private void assertViewHasNoId(int position, V view) {
         if (view.getId() != View.NO_ID) {
-            String errorMessage = String.format(Locale.US, ILLEGAL_STATE_ID_ON_VIEW, view);
+            String errorMessage = String.format(Locale.US, ILLEGAL_STATE_ID_ON_VIEW, position);
             throw new IllegalStateException(errorMessage);
         }
     }

--- a/library/src/main/java/com/novoda/viewpageradapter/ViewPagerAdapter.java
+++ b/library/src/main/java/com/novoda/viewpageradapter/ViewPagerAdapter.java
@@ -73,8 +73,7 @@ public abstract class ViewPagerAdapter<V extends View> extends PagerAdapter {
      * @param view     the page view to bind
      * @param position the position of the data set that is to be represented by this view
      */
-    protected void bindView(V view, int position) {
-    }
+    protected abstract void bindView(V view, int position);
 
     /**
      * Restore state on the given page view.


### PR DESCRIPTION
same as #17 because I'm a bad person and I force pushed.

#### Problem/Goal

Discussed with @rock3r and @ouchadam issues we've had with the API. There were two small points of contention:

- there's no explicit requirement exposed that says clients cannot set View IDs on the pages, and the library just silently overrides the IDs
- we're exposing view state at the point of binding

#### Solution

For the first, we now throw an exception if `createView()` returns a View with an ID already set.

For the second, we extract protected methods for restore (and save, for symmetry) of view state. This means clients can override if necessary, but the binding of the view is still strictly before restoration.

##### Tested?

Checked the demo to ensure that view state was kept (page scroll position and state of subviews), even when views are recreated.

Verified also that `notifyDatasetChanged` does not destroy and recreate all views (this was raised in the discussion, but not related to this change).